### PR TITLE
Fix crash in default binary path detection.

### DIFF
--- a/eagle_automation/default.py
+++ b/eagle_automation/default.py
@@ -6,7 +6,7 @@ import glob
 if 'darwin' == sys.platform:
     eagle_bin = glob.glob('/Applications/EAGLE*/EAGLE.app/Contents/MacOS/EAGLE')[-1]
     open_bin = '/usr/bin/open'
-elif 'linux' == sys.platform:
+elif sys.platform.startswith('linux'):
     eagle_bin = glob.glob('/usr/local/eagle*/bin/eagle')[-1]
     open_bin = '/usr/bin/xdg-open'
 elif 'win32' == sys.platform:

--- a/eagle_automation/default.py
+++ b/eagle_automation/default.py
@@ -3,15 +3,25 @@
 import sys
 import glob
 
+def glob_or_none(glob_path):
+	paths = glob.glob(glob_path)
+	if paths:
+		return paths[-1]
+	else:
+		return None
+
 if 'darwin' == sys.platform:
-    eagle_bin = glob.glob('/Applications/EAGLE*/EAGLE.app/Contents/MacOS/EAGLE')[-1]
+    eagle_bin = glob_or_none('/Applications/EAGLE*/EAGLE.app/Contents/MacOS/EAGLE')
     open_bin = '/usr/bin/open'
 elif sys.platform.startswith('linux'):
-    eagle_bin = glob.glob('/usr/local/eagle*/bin/eagle')[-1]
+    eagle_bin = glob_or_none('/usr/local/eagle*/bin/eagle')
     open_bin = '/usr/bin/xdg-open'
 elif 'win32' == sys.platform:
     eagle_bin = 'c:/program files/EAGLE*/eagle.exe'
     open_bin = 'start'
+else:
+    eagle_bin = None
+    open_bin = None
 
 # LAYERS dictionary provides mapping between Eagle layers and export layers (as
 # used by "eagleexport").


### PR DESCRIPTION
If you have the Eagle binary at an unusual location, `default.py` with raise an exception on import, which prevents you from overriding the default setting in the config file:

```
$ pea --help
Traceback (most recent call last):
  File "/home/avian/local/bin/pea", line 9, in <module>
    load_entry_point('eagle-automation==0.1.12', 'console_scripts', 'pea')()
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 337, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2279, in load_entry_point
    return ep.load()
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 1989, in load
    entry = __import__(self.module_name, globals(),globals(), ['__name__'])
  File "/home/avian/.local/lib/python2.7/site-packages/eagle_automation-0.1.12-py2.7.egg/eagle_automation/pea.py", line 53, in <module>
    from . import config
  File "/home/avian/.local/lib/python2.7/site-packages/eagle_automation-0.1.12-py2.7.egg/eagle_automation/config.py", line 12, in <module>
    from eagle_automation.default import Config
  File "/home/avian/.local/lib/python2.7/site-packages/eagle_automation-0.1.12-py2.7.egg/eagle_automation/default.py", line 30, in <module>
    class Config:
  File "/home/avian/.local/lib/python2.7/site-packages/eagle_automation-0.1.12-py2.7.egg/eagle_automation/default.py", line 99, in Config
    EAGLE = eagle_bin
NameError: name 'eagle_bin' is not defined
```

I also fixed Linux platform detection: Python docs recommend using `sys.platform.startswith` (`sys.platform` is `"linux2"` on my system for instance)
