### PR TITLE
Diff lbr review

### DIFF
--- a/eagle_automation/diff.py
+++ b/eagle_automation/diff.py
@@ -61,7 +61,6 @@ def to_png(in_path, page):
 
             os.unlink(out_path)
 
-        workdir.cleanup()
         return oim
 
 
@@ -73,7 +72,6 @@ def to_txt(in_path):
         export.export(in_path, None, [ out_path ])
 
         directory = open(out_path).read()
-        workdir.cleanup()
         return directory
 
 

--- a/eagle_automation/diff.py
+++ b/eagle_automation/diff.py
@@ -26,6 +26,7 @@ import tempfile
 import subprocess
 
 import logging
+
 log = logging.getLogger('pea').getChild(__name__)
 
 from PIL import Image, ImageOps, ImageChops
@@ -33,13 +34,14 @@ from PIL import Image, ImageOps, ImageChops
 from eagle_automation.config import config
 from eagle_automation.export import get_extension, BadExtension, EaglePNGExport, EagleDirectoryExport
 
+
 def to_png(in_path, page):
     with tempfile.TemporaryDirectory() as workdir:
         extension = in_path.split('.')[-1].lower()
         if extension == 'brd':
             layers = config.LAYERS.values()
-            out_paths = [	os.path.join(workdir, layer + '.png')
-                    for layer in config.LAYERS.keys() ]
+            out_paths = [os.path.join(workdir, layer + '.png')
+                         for layer in config.LAYERS.keys()]
         elif extension == 'sch':
             layers = [{'layers': ['ALL']}]
             out_paths = [os.path.join(workdir, 'all.png')]
@@ -57,7 +59,7 @@ def to_png(in_path, page):
             if oim is None:
                 oim = im
             else:
-                oim = Image.blend(oim, im, 1.0/(1.0+i))
+                oim = Image.blend(oim, im, 1.0 / (1.0 + i))
 
             os.unlink(out_path)
 
@@ -69,145 +71,150 @@ def to_txt(in_path):
         out_path = os.path.join(workdir, "out.txt")
 
         export = EagleDirectoryExport()
-        export.export(in_path, None, [ out_path ])
+        export.export(in_path, None, [out_path])
 
         directory = open(out_path).read()
         return directory
 
 
 def pdf_concatenate(fname, files):
-	from PyPDF2 import PdfFileWriter, PdfFileReader
+    from PyPDF2 import PdfFileWriter, PdfFileReader
 
-	def append_pdf(input,output):
-		[output.addPage(input.getPage(page_num)) for page_num in range(input.numPages)]
+    def append_pdf(input, output):
+        [output.addPage(input.getPage(page_num)) for page_num in range(input.numPages)]
 
-	output = PdfFileWriter()
+    output = PdfFileWriter()
 
-	for f in files:
-		append_pdf(PdfFileReader(open(f, "rb")), output)
+    for f in files:
+        append_pdf(PdfFileReader(open(f, "rb")), output)
 
-	with open(fname, "wb") as f:
-		output.write(f)
+    with open(fname, "wb") as f:
+        output.write(f)
+
 
 def diff_visual(from_file, to_file, page=0, output=None):
-	with tempfile.TemporaryDirectory() as workdir:
-		pages = []
-		first = last = 1
-		preview = False
+    with tempfile.TemporaryDirectory() as workdir:
+        pages = []
+        first = last = 1
+        preview = False
 
-		if not output:
-			output = os.path.join(
-						workdir,
-						"{from_file}-{to_file}.pdf".format(from_file=os.path.basename(from_file).split('.')[0],
-															to_file=os.path.basename(to_file).split('.')[0])
-			)
-			preview = True
+        if not output:
+            output = os.path.join(
+                workdir,
+                "{from_file}-{to_file}.pdf".format(from_file=os.path.basename(from_file).split('.')[0],
+                                                   to_file=os.path.basename(to_file).split('.')[0])
+            )
+            preview = True
 
-		if not page:
-			try:
-				with open(from_file) as _from:
-					with open(to_file) as _to:
-						_from = _from.read()
-						_to = _to.read()
-						# TODO use pyeagle!
-						if not '<schematic' in _from and not '<board' in _from:
-							raise SyntaxError('File {} is not an eagle/xml design file!'.format(from_file))
-						if not '<schematic' in _to and not '<board' in _to:
-							raise SyntaxError('File {} is not an eagle/xml design file!'.format(to_file))
-						if not _from.count('<sheet>') == _to.count('<sheet>'):
-							raise Exception('File {} does not have the same number of sheets as {}'.format(from_file, to_file))
-						last = _from.count('<sheet>') or _from.count('<board')
-			except Exception as err:
-				log.warning(err.message)
-				log.warning("Considering file as an Eagle v5 binary format.")
-				first = last = page
-		else:
-			first = last = page
+        if not page:
+            try:
+                with open(from_file) as _from:
+                    with open(to_file) as _to:
+                        _from = _from.read()
+                        _to = _to.read()
+                        # TODO use pyeagle!
+                        if not '<schematic' in _from and not '<board' in _from:
+                            raise SyntaxError('File {} is not an eagle/xml design file!'.format(from_file))
+                        if not '<schematic' in _to and not '<board' in _to:
+                            raise SyntaxError('File {} is not an eagle/xml design file!'.format(to_file))
+                        if not _from.count('<sheet>') == _to.count('<sheet>'):
+                            raise Exception(
+                                'File {} does not have the same number of sheets as {}'.format(from_file, to_file))
+                        last = _from.count('<sheet>') or _from.count('<board')
+            except Exception as err:
+                log.warning(err.message)
+                log.warning("Considering file as an Eagle v5 binary format.")
+                first = last = page
+        else:
+            first = last = page
 
-		for page in range(first, last+1):
-			log.info("Checking page {} of {}".format(page, last))
-			a_im = to_png(from_file, page=page)
-			b_im = to_png(to_file, page=page)
+        for page in range(first, last + 1):
+            log.info("Checking page {} of {}".format(page, last))
+            a_im = to_png(from_file, page=page)
+            b_im = to_png(to_file, page=page)
 
-			# make the sizes equal
-			# if a sheet contains the filename, it is updated with the temporary name
-			# and may thus change the size of the image
-			width  = max( (a_im.size[0], b_im.size[0]) )
-			height = max( (a_im.size[1], b_im.size[1]) )
-			a_im2 = Image.new( "L", (width,height) )
-			a_im2.paste( a_im, (0,0) )
-			a_im = a_im2
-			a_im2 = None
-			b_im2 = Image.new( "L", (width,height) )
-			b_im2.paste( b_im, (0,0) )
-			b_im = b_im2
-			b_im2 = None
+            # make the sizes equal
+            # if a sheet contains the filename, it is updated with the temporary name
+            # and may thus change the size of the image
+            width = max((a_im.size[0], b_im.size[0]))
+            height = max((a_im.size[1], b_im.size[1]))
+            a_im2 = Image.new("L", (width, height))
+            a_im2.paste(a_im, (0, 0))
+            a_im = a_im2
+            a_im2 = None
+            b_im2 = Image.new("L", (width, height))
+            b_im2.paste(b_im, (0, 0))
+            b_im = b_im2
+            b_im2 = None
 
-			added = ImageOps.autocontrast(ImageChops.subtract(b_im, a_im), 0)
-			deled = ImageOps.autocontrast(ImageChops.subtract(a_im, b_im), 0)
-			same = Image.blend(a_im, b_im, 0.5)
+            added = ImageOps.autocontrast(ImageChops.subtract(b_im, a_im), 0)
+            deled = ImageOps.autocontrast(ImageChops.subtract(a_im, b_im), 0)
+            same = Image.blend(a_im, b_im, 0.5)
 
-			deled = ImageOps.colorize(deled, "#000", "#f00")
-			added = ImageOps.colorize(added, "#000", "#00f")
-			same = ImageOps.colorize(same, "#000", "#777")
+            deled = ImageOps.colorize(deled, "#000", "#f00")
+            added = ImageOps.colorize(added, "#000", "#00f")
+            same = ImageOps.colorize(same, "#000", "#777")
 
-			im = ImageChops.add(ImageChops.add(added, deled), same)
-			fname = "{from_file}-{to_file}-page_{page}.pdf".format(from_file=os.path.basename(from_file.split('.')[0]),
-																							to_file=os.path.basename(to_file.split('.')[0]),
-																							page=page)
-			im.save(os.path.join(workdir, fname))
-			pages.append(os.path.join(workdir, fname))
+            im = ImageChops.add(ImageChops.add(added, deled), same)
+            fname = "{from_file}-{to_file}-page_{page}.pdf".format(from_file=os.path.basename(from_file.split('.')[0]),
+                                                                   to_file=os.path.basename(to_file.split('.')[0]),
+                                                                   page=page)
+            im.save(os.path.join(workdir, fname))
+            pages.append(os.path.join(workdir, fname))
 
-		if len(pages) > 0:
-			pdf_concatenate(output, pages)
-			log.info("Diff output in file: {}".format(output))
-			if preview:
-				try:
-					subprocess.call([config.OPEN, output])
-				except FileNotFoundError as err:
-					log.warning("Cannot find open utility: `{}`".format(config.OPEN))
-					log.warning("Open your file manually to check it")
-				input("Press enter to flush all outputs")
-		else:
-			log.error("No diff output.")
+        if len(pages) > 0:
+            pdf_concatenate(output, pages)
+            log.info("Diff output in file: {}".format(output))
+            if preview:
+                try:
+                    subprocess.call([config.OPEN, output])
+                except FileNotFoundError as err:
+                    log.warning("Cannot find open utility: `{}`".format(config.OPEN))
+                    log.warning("Open your file manually to check it")
+                input("Press enter to flush all outputs")
+        else:
+            log.error("No diff output.")
 
-		workdir.cleanup()
+        workdir.cleanup()
+
 
 def diff_text(from_file, to_file):
-	a_txt = to_txt(from_file)
-	b_txt = to_txt(to_file)
+    a_txt = to_txt(from_file)
+    b_txt = to_txt(to_file)
 
-	a_lines = a_txt.split('\n')
-	b_lines = b_txt.split('\n')
+    a_lines = a_txt.split('\n')
+    b_lines = b_txt.split('\n')
 
-	diff = difflib.unified_diff(a_lines, b_lines, fromfile=from_file, tofile=to_file, lineterm='')
-	print('\n'.join(list(diff)))
+    diff = difflib.unified_diff(a_lines, b_lines, fromfile=from_file, tofile=to_file, lineterm='')
+    print('\n'.join(list(diff)))
+
 
 def diff(from_file, to_file, page=0, output=None):
-	extension = get_extension(from_file)
+    extension = get_extension(from_file)
 
-	if get_extension(to_file) != extension:
-		log.error("%s: both files should have the same extension" % (to_file,))
-		return
+    if get_extension(to_file) != extension:
+        log.error("%s: both files should have the same extension" % (to_file,))
+        return
 
-	if extension == 'brd':
-		diff_visual(from_file, to_file, page, output)
-	elif extension == 'sch':
-		diff_visual(from_file, to_file, page, output)
-	elif extension == 'lbr':
-		diff_text(from_file, to_file)
-	else:
-		log.error("%s: skipping, not a board or schematic" % (from_file,))
-		return
+    if extension == 'brd':
+        diff_visual(from_file, to_file, page, output)
+    elif extension == 'sch':
+        diff_visual(from_file, to_file, page, output)
+    elif extension == 'lbr':
+        diff_text(from_file, to_file)
+    else:
+        log.error("%s: skipping, not a board or schematic" % (from_file,))
+        return
 
 
 ################################################################################
 
 def diff_main(verbose=False):
-	args = docopt.docopt(__doc__.format(prog=sys.argv[0], command=sys.argv[1]))
-	log.debug("Arguments:\n{}".format(repr(args)))
+    args = docopt.docopt(__doc__.format(prog=sys.argv[0], command=sys.argv[1]))
+    log.debug("Arguments:\n{}".format(repr(args)))
 
-	diff(args['<from-file>'], args['<to-file>'], int(args['--page'] if args['--page'] else 0), args['--output'])
+    diff(args['<from-file>'], args['<to-file>'], int(args['--page'] if args['--page'] else 0), args['--output'])
+
 
 if __name__ == '__main__':
-	diff_main()
+    diff_main()

--- a/eagle_automation/diff.py
+++ b/eagle_automation/diff.py
@@ -34,7 +34,7 @@ from eagle_automation.config import config
 from eagle_automation.export import get_extension, BadExtension, EaglePNGExport, EagleDirectoryExport
 
 def to_png(in_path, page):
-	with tempfile.TemporaryDirectory() as workdir:
+    with tempfile.TemporaryDirectory() as workdir:
         extension = in_path.split('.')[-1].lower()
         if extension == 'brd':
             layers = config.LAYERS.values()
@@ -61,21 +61,19 @@ def to_png(in_path, page):
 
             os.unlink(out_path)
 
-		workdir.cleanup()
-
+        workdir.cleanup()
         return oim
 
+
 def to_txt(in_path):
-	with tempfile.TemporaryDirectory() as workdir:
+    with tempfile.TemporaryDirectory() as workdir:
         out_path = os.path.join(workdir, "out.txt")
 
         export = EagleDirectoryExport()
         export.export(in_path, None, [ out_path ])
 
         directory = open(out_path).read()
-
-		workdir.cleanup()
-
+        workdir.cleanup()
         return directory
 
 


### PR DESCRIPTION
Just look at the "INCOMPLETE" commit, it needs the other whitespace fixes first.

I've hacked in the "page" option to swithc between new and old styles...

old:

```
--- askur-dump-lbr/ReMake.lbr
+++ gestur-dump-lbr/ReMake.lbr
@@ -49,10 +49,7 @@
 TPS70933DRV IC      on    SON-6    1*TPS709XX
 TUSB2036   U       on    LQFP-32  1*TUSB2036
 UCLAMP3301H D       off   SOD523   1*ESD5Z3  
-USB_TYPEA_FM X       on    USB_A_FEMALE_CONEC 1*USB_TYPEA_FM
 USB_TYPEA_FMTAITEK_FEMALE X       on    USB_A_FEMALE_TAITEK 1*USB_TYPEA_FM
-USB_TYPEA_FM_CONECTAITEK_FEMALE X       on    USB_A_FEMALE_TAITEK 1*USB_TYPEA_FM
-USB_TYPEA_FM_CONECUSB_A_FEMALE_CONEC X       on    USB_A_FEMALE_TAITEK 1*USB_TYPEA_FM
 USDCARD    X       on    CARDHOLDER_MOLEX 1*USD_CARDHOLDER
 USDCARDDM3AT-SF X       on    DM3AT-SF 1*USD_CARDHOLDER
 VDDA       P+      off   * none * 1*VDDA    
@@ -99,7 +96,6 @@
 TO220
 TO220_HOR
 TO263-5
-USB_A_FEMALE_CONEC
 USB_A_FEMALE_TAITEK
 WE-KI_0805_B
```

New style: (missing some symbols, but that's because this is WIP)
Notice the now caught change in the led footprint

```
$ pea diff --page=1 askur-dump-lbr/ReMake.lbr gestur-dump-lbr/ReMake.lbr 
Packages in old askur-dump-lbr/ReMake.lbr not in new gestur-dump-lbr/ReMake.lbr:
USB_A_FEMALE_CONEC
Package: LED_KNIGHTBRIGHT Pads differ: <SMD 'P$1' (-1.000000, -0.500000)> != <SMD 'P$1' (-1.500000, -0.500000)>
Package: LED_KNIGHTBRIGHT Pads differ: <SMD 'P$2' (1.000000, -0.500000)> != <SMD 'P$2' (1.500000, -0.500000)>
Devices in old askur-dump-lbr/ReMake.lbr not in new gestur-dump-lbr/ReMake.lbr:
USB_TYPEA_FM_CONEC
```
